### PR TITLE
Fix Anki card German display issue

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -18,14 +18,24 @@
             perspective: 1000px;
         }
         .card-inner {
+            position: relative;
             transform-style: preserve-3d;
+            -webkit-transform-style: preserve-3d;
             transition: transform .4s ease;
+            will-change: transform;
         }
         .card.flipped .card-inner { transform: rotateY(180deg); }
         .card-face {
             backface-visibility: hidden;
+            -webkit-backface-visibility: hidden;
         }
-        .card-back { transform: rotateY(180deg); }
+        .card-back {
+            position: absolute;
+            inset: 0;
+            backface-visibility: hidden;
+            -webkit-backface-visibility: hidden;
+            transform: rotateY(180deg);
+        }
         :root { color-scheme: light dark; }
         .dark .text-gray-900 { color: #f3f4f6; }
         .dark .text-gray-600 { color: #9ca3af; }


### PR DESCRIPTION
Fix Anki card content bleed-through by applying `backface-visibility: hidden` and correct 3D transform properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-07389dc9-8a37-4cad-a538-060e85a0b3cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07389dc9-8a37-4cad-a538-060e85a0b3cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

