### PR TITLE
Fix darkmode on cards page

### DIFF
--- a/public/flashcards.html
+++ b/public/flashcards.html
@@ -9,7 +9,7 @@
     <title>Kartenmodus – Meine Wörter</title>
     <script>(function(){try{var s=localStorage.getItem('theme');var d=s?s==='dark':window.matchMedia&&(window.matchMedia('(prefers-color-scheme: dark)').matches);if(d){document.documentElement.classList.add('dark');}}catch(e){}})();</script>
     <script src="/js/theme.js" defer></script>
-    <script>tailwind = { config: { darkMode: 'class' } };</script>
+    <script>try{tailwind=tailwind||{}}catch(e){window.tailwind={}};tailwind.config={darkMode:'class'};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <title>Wichtige japanische Redewendungen für Ihre Reise</title>
     <script>(function(){try{var s=localStorage.getItem('theme');var d=s?s==='dark':window.matchMedia&&(window.matchMedia('(prefers-color-scheme: dark)').matches);if(d){document.documentElement.classList.add('dark');}}catch(e){}})();</script>
     <script src="/js/theme.js" defer></script>
-    <script>tailwind = { config: { darkMode: 'class' } };</script>
+    <script>try{tailwind=tailwind||{}}catch(e){window.tailwind={}};tailwind.config={darkMode:'class'};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <style>

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -26,13 +26,18 @@
   }
 
   function updateSwitchEl(el, checked){
+    var lang = (document.documentElement.getAttribute('lang') || '').toLowerCase();
+    var labelOn = lang === 'de' ? '🌙 Dunkel' : '🌙 Dark';
+    var labelOff = lang === 'de' ? '☀️ Hell' : '☀️ Light';
     if (el.tagName === 'INPUT' && el.type === 'checkbox') {
       el.checked = checked;
       el.setAttribute('aria-checked', checked ? 'true' : 'false');
+      el.setAttribute('title', checked ? labelOn : labelOff);
     } else {
       el.setAttribute('aria-pressed', checked ? 'true' : 'false');
       el.setAttribute('data-checked', checked ? '1' : '0');
-      el.textContent = checked ? '🌙 Dark' : '☀️ Light';
+      el.textContent = checked ? labelOn : labelOff;
+      el.setAttribute('title', checked ? labelOff : labelOn);
     }
   }
 


### PR DESCRIPTION
Consolidate Tailwind dark mode configuration and localize theme toggle text to fix dark mode on the cards page and ensure correct language display.

The dark mode on the cards page was not applying `dark:` classes correctly due to a fragmented Tailwind configuration. Additionally, the theme toggle button displayed English labels even when the page was set to German, leading to a poor user experience. This PR unifies the Tailwind `darkMode: 'class'` configuration and adds language-specific labels for the toggle button.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b560054-adbc-43c2-90b5-a18169997e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b560054-adbc-43c2-90b5-a18169997e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

